### PR TITLE
Restore full services after snapshot validation

### DIFF
--- a/contrib/linearize/example-linearize.cfg
+++ b/contrib/linearize/example-linearize.cfg
@@ -6,14 +6,14 @@ host=127.0.0.1
 port=8772
 
 min_height=0
-max_height=1987853
+max_height=1987888
 
 netmagic=f9beb4d2
 genesis=000000ba5cae4648b1a2b823f84cc3424e5d96d7234b39c6bb42800b2c7639be
 input=/home/example/.blakecoin/blocks
 
 hashlist=hashlist.txt
-output_file=/home/example/blakecoin-bootstrap-1987853.dat
+output_file=/home/example/blakecoin-bootstrap-1987888.dat
 
 out_of_order_cache_sz=100000000
 rev_hash_bytes=False

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1490,6 +1490,14 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
         node.chainman = std::make_unique<ChainstateManager>(chainman_opts, blockman_opts);
         ChainstateManager& chainman = *node.chainman;
+        chainman.snapshot_validation_completed = [&node]() {
+            if (!Assert(node.chainman)->m_blockman.IsPruneMode()) {
+                LogPrintf("[snapshot] re-enabling NODE_NETWORK services\n");
+                if (node.connman) {
+                    node.connman->AddLocalServices(NODE_NETWORK);
+                }
+            }
+        };
 
         node::ChainstateLoadOptions options;
         options.mempool = Assert(node.mempool.get());
@@ -1615,8 +1623,13 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             }
         }
     } else {
-        LogPrintf("Setting NODE_NETWORK on non-prune mode\n");
-        nLocalServices = ServiceFlags(nLocalServices | NODE_NETWORK);
+        const bool snapshot_pending_validation{WITH_LOCK(cs_main, return chainman.IsSnapshotActive() && !chainman.IsSnapshotValidated())};
+        if (snapshot_pending_validation) {
+            LogPrintf("Running node in NODE_NETWORK_LIMITED mode until snapshot background validation completes\n");
+        } else {
+            LogPrintf("Setting NODE_NETWORK on non-prune mode\n");
+            nLocalServices = ServiceFlags(nLocalServices | NODE_NETWORK);
+        }
     }
 
     // ********************************************************* Step 11: import blocks

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5578,6 +5578,9 @@ SnapshotCompletionResult ChainstateManager::MaybeCompleteSnapshotValidation(
 
     m_ibd_chainstate->m_disabled = true;
     this->MaybeRebalanceCaches();
+    if (snapshot_validation_completed) {
+        snapshot_validation_completed();
+    }
 
     return SnapshotCompletionResult::SUCCESS;
 }

--- a/src/validation.h
+++ b/src/validation.h
@@ -35,6 +35,7 @@
 #include <versionbits.h>
 
 #include <atomic>
+#include <functional>
 #include <map>
 #include <memory>
 #include <optional>
@@ -957,6 +958,9 @@ public:
     using Options = kernel::ChainstateManagerOpts;
 
     explicit ChainstateManager(Options options, node::BlockManager::Options blockman_options);
+
+    //! Called after a loaded snapshot has been fully validated by the background chainstate.
+    std::function<void()> snapshot_validation_completed;
 
     const CChainParams& GetParams() const { return m_options.chainparams; }
     const Consensus::Params& GetConsensus() const { return m_options.chainparams.GetConsensus(); }


### PR DESCRIPTION
Re-enable NODE_NETWORK advertising for non-pruned nodes after background assumeutxo validation completes.

Keep nodes in NODE_NETWORK_LIMITED mode across startup while snapshot validation is still pending.

Align the linearize bootstrap example with the mainnet assumeutxo snapshot height.