### PR TITLE
Align Blakecoin metrics and testnet policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ digital currency with no central authority.
 | Coinbase maturity | 100 blocks through historical 15.21 replay; 120 blocks from height 1,996,240 |
 | Default P2P port | 8773 |
 | RPC port | 8772 |
+| Max money sanity range | `21000000 * COIN` legacy transaction money-range consensus limit |
 | Max supply policy | 7,000,000,000 BLC target supply policy |
 | Mainnet genesis | `000000ba5cae4648b1a2b823f84cc3424e5d96d7234b39c6bb42800b2c7639be` |
 | Mainnet Bech32 HRP | `blc` |

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,87 @@
+Blakecoin Core
+=============
+
+Setup
+---------------------
+Blakecoin Core is the Blakecoin full node and wallet software. It downloads and, by default, stores the full Blakecoin chain history. Depending on the speed of your computer and network connection, the synchronization process can take time to complete.
+
+To download Blakecoin Core, visit the Blakecoin project repository.
+
+Running
+---------------------
+The following are some helpful notes on how to run Blakecoin Core on your native platform.
+
+### Unix
+
+Unpack the files into a directory and run:
+
+- `bin/blakecoin-qt` (GUI) or
+- `bin/blakecoind` (headless)
+
+### Windows
+
+Unpack the files into a directory, and then run blakecoin-qt.exe.
+
+### macOS
+
+Drag Blakecoin Core to your applications folder, and then run Blakecoin Core.
+
+### Need Help?
+
+* See the Blakecoin project repository for help and more information.
+
+Building
+---------------------
+The following are developer notes on how to build Blakecoin Core on your native platform. They are not complete guides, but include notes on the necessary libraries, compile flags, etc.
+
+- [Dependencies](dependencies.md)
+- [macOS Build Notes](build-osx.md)
+- [Unix Build Notes](build-unix.md)
+- [Windows Build Notes](build-windows.md)
+- [FreeBSD Build Notes](build-freebsd.md)
+- [OpenBSD Build Notes](build-openbsd.md)
+- [NetBSD Build Notes](build-netbsd.md)
+- [Android Build Notes](build-android.md)
+
+Development
+---------------------
+The Blakecoin repo's [root README](/README.md) contains relevant information on the development process and automated testing.
+
+- [Developer Notes](developer-notes.md)
+- [Productivity Notes](productivity.md)
+- [Release Process](release-process.md)
+- [Source Code Documentation (External Link)](https://doxygen.bitcoincore.org/)
+- [Translation Process](translation_process.md)
+- [Translation Strings Policy](translation_strings_policy.md)
+- [JSON-RPC Interface](JSON-RPC-interface.md)
+- [Unauthenticated REST Interface](REST-interface.md)
+- [Shared Libraries](shared-libraries.md)
+- [BIPS](bips.md)
+- [Dnsseed Policy](dnsseed-policy.md)
+- [Benchmarking](benchmarking.md)
+- [Internal Design Docs](design/)
+
+### Resources
+* Discuss project-specific development through the Blakecoin project channels.
+
+### Miscellaneous
+- [Assets Attribution](assets-attribution.md)
+- [blakecoin.conf Configuration File](blakecoin-conf.md)
+- [CJDNS Support](cjdns.md)
+- [Files](files.md)
+- [Fuzz-testing](fuzzing.md)
+- [I2P Support](i2p.md)
+- [Init Scripts (systemd/upstart/openrc)](init.md)
+- [Managing Wallets](managing-wallets.md)
+- [Multisig Tutorial](multisig-tutorial.md)
+- [P2P bad ports definition and list](p2p-bad-ports.md)
+- [PSBT support](psbt.md)
+- [Reduce Memory](reduce-memory.md)
+- [Reduce Traffic](reduce-traffic.md)
+- [Tor Support](tor.md)
+- [Transaction Relay Policy](policy/README.md)
+- [ZMQ](zmq.md)
+
+License
+---------------------
+Distributed under the [MIT software license](/COPYING).

--- a/doc/policy/README.md
+++ b/doc/policy/README.md
@@ -1,0 +1,14 @@
+# Transaction Relay Policy
+
+**Policy** (Mempool or Transaction Relay Policy) is the node's set of validation rules, in addition
+to consensus, enforced for unconfirmed transactions before submitting them to the mempool. These
+rules are local to the node and configurable (e.g. `-minrelaytxfee`, `-limitancestorsize`,
+`-incrementalrelayfee`). Policy may include restrictions on the transaction itself, the transaction
+in relation to the current chain tip, and the transaction in relation to the node's mempool
+contents. Policy is *not* applied to transactions in blocks.
+
+This documentation is not an exhaustive list of all policy rules.
+
+- [Mempool Limits](mempool-limits.md)
+- [Mempool Replacements](mempool-replacements.md)
+- [Packages](packages.md)

--- a/src/consensus/amount.h
+++ b/src/consensus/amount.h
@@ -11,17 +11,14 @@
 /** Amount in satoshis (Can be negative) */
 typedef int64_t CAmount;
 
-/** The amount of satoshis in one BTC. */
+/** The amount of satoshis in one BLC. */
 static constexpr CAmount COIN = 100000000;
 
 /** No amount larger than this (in satoshi) is valid.
  *
- * Note that this constant is *not* the total money supply, which in Bitcoin
- * currently happens to be less than 21,000,000 BTC for various reasons, but
- * rather a sanity check. As this sanity check is used by consensus-critical
- * validation code, the exact value of the MAX_MONEY constant is consensus
- * critical; in unusual circumstances like a(nother) overflow bug that allowed
- * for the creation of coins out of thin air modification could lead to a fork.
+ * This is Blakecoin's consensus-critical transaction money-range sanity
+ * limit inherited from the released legacy chain, not a promise of final
+ * emitted supply. Changing it can fork historical replay.
  * */
 static constexpr CAmount MAX_MONEY = 21000000 * COIN;
 inline bool MoneyRange(const CAmount& nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -223,11 +223,13 @@ public:
         // waiting on the 0.15.21 mainnet activation. Do NOT change.
         consensus.SegwitHeight = 1;
         consensus.MinBIP9WarningHeight = 0;
-        consensus.powLimit = uint256S("000000ffff000000000000000000000000000000000000000000000000000000");
+        // Private 25.2 feature-testnet uses regtest-style PoW so local CPU
+        // pool tests can advance blocks quickly while mainnet stays unchanged.
+        consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 20 * 3 * 60;
         consensus.nPowTargetSpacing = 3 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
-        consensus.fPowNoRetargeting = false;
+        consensus.fPowNoRetargeting = true;
         consensus.nRuleChangeActivationThreshold = 15;
         consensus.nMinerConfirmationWindow = 20;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;

--- a/src/policy/feerate.cpp
+++ b/src/policy/feerate.cpp
@@ -8,13 +8,23 @@
 #include <tinyformat.h>
 
 #include <cmath>
+#include <limits>
+
+namespace {
+CAmount ClampFeeRate(__int128 value)
+{
+    if (value > std::numeric_limits<CAmount>::max()) return std::numeric_limits<CAmount>::max();
+    if (value < std::numeric_limits<CAmount>::min()) return std::numeric_limits<CAmount>::min();
+    return static_cast<CAmount>(value);
+}
+} // namespace
 
 CFeeRate::CFeeRate(const CAmount& nFeePaid, uint32_t num_bytes)
 {
     const int64_t nSize{num_bytes};
 
     if (nSize > 0) {
-        nSatoshisPerK = nFeePaid * 1000 / nSize;
+        nSatoshisPerK = ClampFeeRate(static_cast<__int128>(nFeePaid) * 1000 / nSize);
     } else {
         nSatoshisPerK = 0;
     }

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -249,7 +249,7 @@
                <string>Your current total balance</string>
               </property>
               <property name="text">
-               <string notr="true">21 000 000.00000000 BLC</string>
+               <string notr="true">7 000 000 000.00000000 BLC</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -268,7 +268,7 @@
                <string>Current total balance in watch-only addresses</string>
               </property>
               <property name="text">
-               <string notr="true">21 000 000.00000000 BLC</string>
+               <string notr="true">7 000 000 000.00000000 BLC</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -304,7 +304,7 @@
                <string>Your current spendable balance</string>
               </property>
               <property name="text">
-               <string notr="true">21 000 000.00000000 BLC</string>
+               <string notr="true">7 000 000 000.00000000 BLC</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -323,7 +323,7 @@
                <string>Your current balance in watch-only addresses</string>
               </property>
               <property name="text">
-               <string notr="true">21 000 000.00000000 BLC</string>
+               <string notr="true">7 000 000 000.00000000 BLC</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -80,7 +80,7 @@ int main(int argc, char* argv[])
     #endif
 
     BitcoinApplication app;
-    app.setApplicationName("Bitcoin-Qt-test");
+    app.setApplicationName("Blakecoin-Qt-test");
     app.createNode(*init);
 
     int num_test_failures{0};

--- a/src/test/amount_tests.cpp
+++ b/src/test/amount_tests.cpp
@@ -16,6 +16,7 @@ BOOST_AUTO_TEST_CASE(MoneyRangeTest)
     BOOST_CHECK_EQUAL(MoneyRange(CAmount(-1)), false);
     BOOST_CHECK_EQUAL(MoneyRange(CAmount(0)), true);
     BOOST_CHECK_EQUAL(MoneyRange(CAmount(1)), true);
+    BOOST_CHECK_EQUAL(MAX_MONEY, 21000000 * COIN);
     BOOST_CHECK_EQUAL(MoneyRange(MAX_MONEY), true);
     BOOST_CHECK_EQUAL(MoneyRange(MAX_MONEY + CAmount(1)), false);
 }

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -37,7 +37,7 @@ MAX_BLOCK_WEIGHT = 4000000
 MAX_BLOOM_FILTER_SIZE = 36000
 MAX_BLOOM_HASH_FUNCS = 50
 
-COIN = 100000000  # 1 btc in satoshis
+COIN = 100000000  # 1 BLC in satoshis
 MAX_MONEY = 21000000 * COIN
 
 MAX_BIP125_RBF_SEQUENCE = 0xfffffffd  # Sequence number that is rbf-opt-in (BIP 125) and csv-opt-out (BIP 68)
@@ -632,7 +632,7 @@ class CTransaction:
     def is_valid(self):
         self.calc_sha256()
         for tout in self.vout:
-            if tout.nValue < 0 or tout.nValue > 21000000 * COIN:
+            if tout.nValue < 0 or tout.nValue > MAX_MONEY:
                 return False
         return True
 


### PR DESCRIPTION
Align BLC unit branding in amount comments, test framework constants, Qt balance placeholders, and the Qt test application name.

Use the shared MAX_MONEY constant in the functional test transaction validity check.

Make fee-rate construction use wide intermediate arithmetic and clamp out-of-range results.

Make Blakecoin 25.2 testnet easy to mine locally with a regtest-style proof-of-work limit and retargeting disabled.

Add Blakecoin Core documentation indexes for platform run notes, build references, development links, configuration docs, and transaction relay policy.